### PR TITLE
Feature/force inmemory and db groups sync

### DIFF
--- a/ScheduleBot/ScheduleBot.AspHost/BotServices/InMemoryBotStorage.cs
+++ b/ScheduleBot/ScheduleBot.AspHost/BotServices/InMemoryBotStorage.cs
@@ -22,7 +22,7 @@ namespace ScheduleBot.AspHost.BotServices
     public class InMemoryBotStorage : IBotDataStorage
     {
         private readonly IScheduleService service;
-        private readonly INotifiactionSender notifiactionSender;
+        private readonly INotifiactionSender notificationSender;
         private readonly IUsersGroupsRepository usersGroupsRepository;
         private readonly ILogger<InMemoryBotStorage> logger;
 
@@ -35,11 +35,11 @@ namespace ScheduleBot.AspHost.BotServices
         private const string XmlFileName = "usersgroups.xml";
         private readonly string path;
 
-        public InMemoryBotStorage(IScheduleService service, INotifiactionSender notifiactionSender, IUsersGroupsRepository usersGroupsRepository,
+        public InMemoryBotStorage(IScheduleService service, INotifiactionSender notificationSender, IUsersGroupsRepository usersGroupsRepository,
             ILogger<InMemoryBotStorage> logger = null)
         {
             this.service = service;
-            this.notifiactionSender = notifiactionSender;
+            this.notificationSender = notificationSender;
             this.usersGroupsRepository = usersGroupsRepository;
             this.logger = logger;
             var usersWithGroups = usersGroupsRepository.GetAllUsersWithGroupsAsync().Result;
@@ -80,7 +80,7 @@ namespace ScheduleBot.AspHost.BotServices
                             JsonConvert.SerializeObject(group), JsonConvert.SerializeObject(list));
                         var dayName = new CultureInfo("ru-Ru").DateTimeFormat.GetDayName(paramEventArgs.Param);
                         var verbEnd = dayName.EndsWith('а') ? "ась" : "ся";
-                        await notifiactionSender.SendNotificationsForIdsAsync(list,
+                        await notificationSender.SendNotificationsForIdsAsync(list,
                             $"Изменил{verbEnd} {dayName}");
                     }
                 }

--- a/ScheduleBot/ScheduleBot.AspHost/DAL/Repositories/Impls/UsersGroupsDbRepository.cs
+++ b/ScheduleBot/ScheduleBot.AspHost/DAL/Repositories/Impls/UsersGroupsDbRepository.cs
@@ -126,7 +126,7 @@ namespace ScheduleBot.AspHost.DAL.Repositories.Impls
             }
             catch (Exception e)
             {
-                logger.LogError(e, "Exception during groups sync with db");
+                logger?.LogError(e, "Exception during groups sync with db");
                 if (throwExceptionOnFall)
                     throw;
             }

--- a/ScheduleBot/ScheduleBot.AspHost/DAL/Repositories/Impls/UsersGroupsDbRepository.cs
+++ b/ScheduleBot/ScheduleBot.AspHost/DAL/Repositories/Impls/UsersGroupsDbRepository.cs
@@ -16,7 +16,7 @@ namespace ScheduleBot.AspHost.DAL.Repositories.Impls
     {
         private readonly UsersContextFactory dbFactory;
         private readonly ILogger<UsersGroupsDbRepository> logger;
-
+        
         public UsersGroupsDbRepository(UsersContextFactory dbFactory, ILogger<UsersGroupsDbRepository> logger = null)
         {
             this.dbFactory = dbFactory;
@@ -30,7 +30,8 @@ namespace ScheduleBot.AspHost.DAL.Repositories.Impls
                     .ToListAsync();
             }
         }
-
+        
+        /// <inheritdoc cref="IUsersGroupsRepository.FindUserByChatIdAsync"/>
         public async Task<Profile> FindUserByChatIdAsync(long chatId)
         {
             using (var context = dbFactory.CreateDbContext())
@@ -39,6 +40,7 @@ namespace ScheduleBot.AspHost.DAL.Repositories.Impls
             }
         }
 
+        /// <inheritdoc cref="IUsersGroupsRepository.AddGroupToUserAsync"/>
         public async Task AddGroupToUserAsync(Profile user, IScheduleGroup group)
         {
             if (group is ScheduleGroup schGroup)
@@ -61,6 +63,7 @@ namespace ScheduleBot.AspHost.DAL.Repositories.Impls
             }
         }
 
+        /// <inheritdoc cref="IUsersGroupsRepository.SetSingleGroupToUserAsync"/>
         public async Task SetSingleGroupToUserAsync(Profile user, IScheduleGroup group)
         {
             if (group is ScheduleGroup schGroup)
@@ -80,6 +83,7 @@ namespace ScheduleBot.AspHost.DAL.Repositories.Impls
             }
         }
 
+        /// <inheritdoc cref="IUsersGroupsRepository.ReplaceGroupAsync"/>
         public async Task ReplaceGroupAsync(Profile user, IScheduleGroup oldGroup, IScheduleGroup newGroup)
         {
             if (newGroup is ScheduleGroup schGroup && oldGroup is ScheduleGroup oldSchGroup)
@@ -100,6 +104,7 @@ namespace ScheduleBot.AspHost.DAL.Repositories.Impls
             }
         }
 
+        /// <inheritdoc cref="IUsersGroupsRepository.SyncGroupsFromSource"/>
         public async Task SyncGroupsFromSource(IEnumerable<IScheduleGroup> groups, bool throwExceptionOnFall = true)
         {
             try

--- a/ScheduleBot/ScheduleBot.AspHost/DAL/Repositories/Interfaces/IUsersGroupsRepository.cs
+++ b/ScheduleBot/ScheduleBot.AspHost/DAL/Repositories/Interfaces/IUsersGroupsRepository.cs
@@ -10,12 +10,55 @@ namespace ScheduleBot.AspHost.DAL.Repositories.Interfaces
 {
     public interface IUsersGroupsRepository
     {
+        /// <summary>
+        /// Returns all users and all their groups in navigation properties
+        /// </summary>
+        /// <returns>All users with their groups from storage</returns>
         Task<IList<Profile>> GetAllUsersWithGroupsAsync();
+
+        /// <summary>
+        /// Returns user with given chatId with all his groups
+        /// </summary>
+        /// <param name="chatId">User's chatId</param>
+        /// <returns>Profile of user with all groups</returns>
         Task<Profile> FindUserByChatIdAsync(long chatId);
+
+        /// <summary>
+        /// Just adds group to list of user's groups.
+        /// If there is no such group yet, it will be added.
+        /// </summary>
+        /// <param name="user">Profile of user</param>
+        /// <param name="group">Group to add</param>
+        /// <returns></returns>
         Task AddGroupToUserAsync(Profile user, IScheduleGroup group);
+
+        /// <summary>
+        /// Removes all groups from user and add single to his groups.
+        /// If there is no such group yet, it will be added.
+        /// </summary>
+        /// <param name="user">Profile of user</param>
+        /// <param name="group">Group to be added</param>
+        /// <returns></returns>
         Task SetSingleGroupToUserAsync(Profile user, IScheduleGroup group);
+
+        /// <summary>
+        /// Replaces specified group by another for user.
+        /// If there is no such new group yet, it will be added.
+        /// </summary>
+        /// <param name="user">Profile of user</param>
+        /// <param name="oldGroup">Group which will be replaced</param>
+        /// <param name="newGroup">Group which will replace</param>
+        /// <returns></returns>
         Task ReplaceGroupAsync(Profile user, IScheduleGroup oldGroup, IScheduleGroup newGroup);
 
+        /// <summary>
+        /// Takes source and compare it with stored groups. Groups will be removed from storage,
+        /// if they not exist in source. Groups will be added to storage, if they exist in source but not in storage.
+        /// Groups will be updated if they match by predefined key: stored groups will take info, source groups will take storage id's
+        /// </summary>
+        /// <param name="groups">Source groups list</param>
+        /// <param name="throwExceptionOnFall">Flag to throw exception on fail.</param>
+        /// <returns></returns>
         Task SyncGroupsFromSource(IEnumerable<IScheduleGroup> groups, bool throwExceptionOnFall = true);
     }
 }

--- a/ScheduleBot/ScheduleBot.AspHost/DAL/Repositories/Interfaces/IUsersGroupsRepository.cs
+++ b/ScheduleBot/ScheduleBot.AspHost/DAL/Repositories/Interfaces/IUsersGroupsRepository.cs
@@ -15,5 +15,7 @@ namespace ScheduleBot.AspHost.DAL.Repositories.Interfaces
         Task AddGroupToUserAsync(Profile user, IScheduleGroup group);
         Task SetSingleGroupToUserAsync(Profile user, IScheduleGroup group);
         Task ReplaceGroupAsync(Profile user, IScheduleGroup oldGroup, IScheduleGroup newGroup);
+
+        Task SyncGroupsFromSource(IEnumerable<IScheduleGroup> groups, bool throwExceptionOnFall = true);
     }
 }


### PR DESCRIPTION
this PR updates flow for db storage to keep "Groups" table up to date with static groups set in startup.